### PR TITLE
Add SimpleP2E deployment script

### DIFF
--- a/.envrc.sample
+++ b/.envrc.sample
@@ -18,3 +18,23 @@ export SBT_BASE_URI="https://token/"
 # - The admin can grant privileged access rights.
 # - The admin initially holds the minting role.
 export SBT_ADMIN="0x0000000000000000000000000000000000000000"
+
+# --------------------------------------------
+# For SimpleP2E
+# --------------------------------------------
+# The pOAS token address
+export P2E_POAS="0x0000000000000000000000000000000000000000"
+# The address of the WOAS-SMP liquidity pool
+export P2E_LIQUIDITY_POOL="0x0000000000000000000000000000000000000000"
+# Recipient of LP tokens from protocol operations
+export P2E_LP_RECIPIENT="0x0000000000000000000000000000000000000000"
+# Recipient of protocol revenue (OAS)
+export P2E_REVENUE_RECIPIENT="0x0000000000000000000000000000000000000000"
+# Base price per NFT in SMP (wei)
+export P2E_SMP_BASE_PRICE=50000000000000000000
+# Ratio of SMP to burn (in basis points)
+export P2E_SMP_BURN_RATIO=5000
+# Ratio of SMP to provide as liquidity (in basis points)
+export P2E_SMP_LIQUIDITY_RATIO=4000
+# Proxy admin and initial owner of the contract
+export P2E_ADMIN="0x0000000000000000000000000000000000000000"


### PR DESCRIPTION
## Summary
- add `DeploySimpleP2E.s.sol` to deploy the SimpleP2E contract through a transparent proxy
- extend `.envrc.sample` with variables needed by the new deployment script

## Testing
- `npm test` *(fails: `forge` not found)*
- `npm run build` *(fails: `forge` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68637f926cb4833089e0f9f2e4bbe17c