### PR TITLE
Rename SimpleP2E to SBTSale

### DIFF
--- a/.envrc.sample
+++ b/.envrc.sample
@@ -20,7 +20,7 @@ export SBT_BASE_URI="https://token/"
 export SBT_ADMIN="0x0000000000000000000000000000000000000000"
 
 # --------------------------------------------
-# For SimpleP2E
+# For SBTSale
 # --------------------------------------------
 # The pOAS token address
 export P2E_POAS_MINTER="0x0000000000000000000000000000000000000000"

--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ npm test
 ## Contracts
 - SimpleGame
   - The main contract that users interact with to play the game. (Not yet implemented.)
-- [SimpleP2E](./contracts/SimpleP2E.sol)
-  - A sales contract for minting SBTs (Soulbound Tokens).Supports payment in SMP Token, native OAS, Wrapped OAS, and pOAS.
+- [SBTSale](./contracts/SBTSale.sol)
+  - Contract used to sell SBTs (Soulbound Tokens). Supports payment in SMP Token,
+    native OAS, Wrapped OAS, and pOAS.
   - The price of each SBT is denominated in SMP tokens. When other tokens are used for payment, they are swapped to SMP via the Gaming DEX.
 - [SoulboundToken](./contracts/SoulboundToken.sol)
   - An SBT (Soulbound Token) contract representing "Cards" used in the game.

--- a/contracts/SBTSale.sol
+++ b/contracts/SBTSale.sol
@@ -26,11 +26,11 @@ import {IPOAS} from "./interfaces/IPOAS.sol";
 import {IPOASMinter} from "./interfaces/IPOASMinter.sol";
 
 /**
- * @title SimpleP2E
- * @dev Play-to-Earn game contract that accepts payments in multiple token types
- *      Implements complex payment flow with SMP burning, liquidity provision, and revenue distribution
+ * @title SBTSale
+ * @dev Contract for selling SBTs using multiple payment tokens. Handles SMP burning,
+ *      liquidity provision and revenue distribution.
  */
-contract SimpleP2E is ISimpleP2E, OwnableUpgradeable, ReentrancyGuardUpgradeable {
+contract SBTSale is ISimpleP2E, OwnableUpgradeable, ReentrancyGuardUpgradeable {
     using SafeERC20 for IERC20;
 
     /// @dev Data structure for swap operation

--- a/contracts/interfaces/ISimpleP2EERC721.sol
+++ b/contracts/interfaces/ISimpleP2EERC721.sol
@@ -5,7 +5,7 @@ import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 
 /**
  * @title ISimpleP2EERC721
- * @dev Interface for ERC721 tokens that can be minted by SimpleP2E contract
+ * @dev Interface for ERC721 tokens that can be minted by SBTSale contract
  */
 interface ISimpleP2EERC721 is IERC721 {
     /**

--- a/contracts/test-utils/MockSimpleP2EERC721.sol
+++ b/contracts/test-utils/MockSimpleP2EERC721.sol
@@ -6,22 +6,22 @@ import {ISimpleP2EERC721} from "../interfaces/ISimpleP2EERC721.sol";
 
 /**
  * @title MockSimpleP2EERC721
- * @notice Mock implementation of ERC721 token for testing P2E game contract
+ * @notice Mock implementation of ERC721 token for testing the sale contract
  * @dev This contract implements the ISimpleP2EERC721 interface for testing purposes.
- *      Only the designated SimpleP2E contract can mint tokens.
+ *      Only the designated SBTSale contract can mint tokens.
  */
 contract MockSimpleP2EERC721 is ISimpleP2EERC721, ERC721 {
     /// @dev Counter for generating unique token IDs, starting from 0
     uint256 private _nextTokenId;
 
-    /// @notice Address of the SimpleP2E contract that is allowed to mint tokens
+    /// @notice Address of the SBTSale contract that is allowed to mint tokens
     address public immutable simpleP2E;
 
     /**
      * @notice Constructor to initialize the NFT collection
      * @param name The name of the NFT collection
      * @param symbol The symbol of the NFT collection
-     * @param _simpleP2E Address of the SimpleP2E contract that can mint tokens
+     * @param _simpleP2E Address of the SBTSale contract that can mint tokens
      */
     constructor(string memory name, string memory symbol, address _simpleP2E)
         ERC721(name, symbol)
@@ -31,12 +31,12 @@ contract MockSimpleP2EERC721 is ISimpleP2EERC721, ERC721 {
 
     /**
      * @notice Mint a new NFT to the specified address
-     * @dev Only the SimpleP2E contract can call this function
+     * @dev Only the SBTSale contract can call this function
      * @param to Address to mint the NFT to
      * @return tokenId The ID of the newly minted token
      */
     function mint(address to) external returns (uint256 tokenId) {
-        require(msg.sender == simpleP2E, "Only SimpleP2E can mint");
+        require(msg.sender == simpleP2E, "Only SBTSale can mint");
 
         // Generate unique token ID and increment counter
         tokenId = _nextTokenId++;

--- a/contracts/test-utils/TestUtilsImporter.sol
+++ b/contracts/test-utils/TestUtilsImporter.sol
@@ -14,14 +14,14 @@ import {IVault} from "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
 import {IBasePoolFactory} from
     "@balancer-labs/v2-interfaces/contracts/pool-utils/IBasePoolFactory.sol";
 
-// SimpleP2E
+// SBTSale
 import {IVaultPool} from "../interfaces/IVaultPool.sol";
 import {IPOAS} from "../interfaces/IPOAS.sol";
 import {IPOASMinter} from "../interfaces/IPOASMinter.sol";
 import {ISimpleP2E} from "../interfaces/ISimpleP2E.sol";
 import {IWOAS} from "../interfaces/IWOAS.sol";
 import {ISimpleP2EERC721} from "../interfaces/ISimpleP2EERC721.sol";
-import {SimpleP2E} from "../SimpleP2E.sol";
+import {SBTSale} from "../SBTSale.sol";
 
 // Test utilities
 import {IBalancerV2Helper} from "./interfaces/IBalancerV2Helper.sol";

--- a/hardhat/test-utils/index.ts
+++ b/hardhat/test-utils/index.ts
@@ -1,7 +1,7 @@
 /**
- * @fileoverview Test deployment utilities for SimpleP2E game contracts
+ * @fileoverview Test deployment utilities for SBTSale contracts
  * @description This module provides comprehensive helper functions for deploying and configuring
- *              the complete SimpleP2E ecosystem. It includes Balancer V2 infrastructure deployment,
+ *              the complete SBTSale ecosystem. It includes Balancer V2 infrastructure deployment,
  *              mock token creation, liquidity pool setup, and P2E game contract deployment.
  *
  *              Key Features:
@@ -9,7 +9,7 @@
  *              - Automated Balancer V2 ecosystem setup (Vault, Pool Factory, Helper)
  *              - Mock token deployment (SMP, POAS) with proper permissions
  *              - Liquidity pool creation and initial funding
- *              - SimpleP2E contract deployment with configurable parameters
+ *              - SBTSale contract deployment with configurable parameters
  *              - Mock NFT contract factory for testing scenarios
  */
 
@@ -161,7 +161,7 @@ export const deployBalancerV2 = async (params?: {
 };
 
 /**
- * @notice Deploys the complete SimpleP2E ecosystem including all dependencies
+ * @notice Deploys the complete SBTSale ecosystem including all dependencies
  * @dev Orchestrates the deployment of the entire P2E game testing environment:
  *
  *      Phase 1 - Infrastructure Setup:
@@ -174,7 +174,7 @@ export const deployBalancerV2 = async (params?: {
  *      - Retrieves pool address from creation events
  *
  *      Phase 3 - P2E Contract Deployment:
- *      - Deploys SimpleP2E contract with configurable parameters
+ *      - Deploys SBTSale contract with configurable parameters
  *      - Sets up burn ratios, liquidity ratios, and price configurations
  *
  *      Phase 4 - Initial Liquidity Setup:
@@ -187,7 +187,7 @@ export const deployBalancerV2 = async (params?: {
  * @param params.initialLiquidity Initial liquidity amounts for the WOAS-SMP pool
  * @param params.initialLiquidity.woas Amount of WOAS to add to pool (in wei)
  * @param params.initialLiquidity.smp Amount of SMP to add to pool (in wei)
- * @param params.p2e SimpleP2E contract configuration parameters
+ * @param params.p2e SBTSale contract configuration parameters
  * @param params.p2e.lpRecipient Address to receive LP tokens from protocol operations
  * @param params.p2e.revenueRecipient Address to receive revenue from token sales
  * @param params.p2e.smpBasePrice Price per NFT in SMP tokens (default: 50 SMP)
@@ -200,9 +200,9 @@ export const deployBalancerV2 = async (params?: {
  * @returns poas - Mock POAS token contract for testing payments
  * @returns smp - Mock SMP token contract for testing game economy
  * @returns pool - WOAS-SMP liquidity pool contract
- * @returns p2e - Deployed SimpleP2E game contract
- */
-export const deploySimpleP2E = async (params: {
+ * @returns p2e - Deployed SBTSale contract
+*/
+export const deploySBTSale = async (params: {
   initialLiquidity: {
     woas: bigint;
     smp: bigint;
@@ -256,7 +256,7 @@ export const deploySimpleP2E = async (params: {
   const pool = await getContractAt("IVaultPool", poolAddr!);
 
   const p2eImpl = await deployContract(
-    "SimpleP2E",
+    "SBTSale",
     [
       poasMinter.address,
       pool.address,
@@ -325,17 +325,17 @@ export const deploySimpleP2E = async (params: {
 };
 
 /**
- * @notice Deploys multiple mock NFT contracts for testing P2E scenarios
+ * @notice Deploys multiple mock NFT contracts for testing sale scenarios
  * @dev Creates the specified number of MockSimpleP2EERC721 contracts with unique
  *      names and symbols. Each NFT contract is configured to only allow minting
- *      from the specified SimpleP2E contract, ensuring proper access control.
+ *      from the specified SBTSale contract, ensuring proper access control.
  *
  *      Generated contracts will have:
  *      - Sequential names: "NFT1", "NFT2", "NFT3", etc.
  *      - Sequential symbols: "NFT1", "NFT2", "NFT3", etc.
- *      - Minting permission restricted to the provided SimpleP2E address
+ *      - Minting permission restricted to the provided SBTSale address
  *
- * @param simpleP2E Address of the SimpleP2E contract that can mint these NFTs
+ * @param simpleP2E Address of the SBTSale contract that can mint these NFTs
  * @param count Number of NFT contracts to deploy (must be > 0)
  * @returns Array of deployed NFT contract instances, indexed from 0
  *

--- a/hardhat/test/SBTSale.ts
+++ b/hardhat/test/SBTSale.ts
@@ -4,11 +4,11 @@ import { ContractTypesMap } from "hardhat/types/artifacts";
 import { Address, checksumAddress, parseEther } from "viem";
 
 import {
-  deploySimpleP2E,
+  deploySBTSale,
   deployMockERC721,
 } from "@oasysgames/simple-p2e-game-hardhat/test-utils";
 
-describe("TestSimpleP2E", () => {
+describe("TestSBTSale", () => {
   let p2e: ContractTypesMap["ISimpleP2E"];
   let woas: ContractTypesMap["IWOAS"];
   let poasMinter: ContractTypesMap["MockPOASMinter"];
@@ -38,8 +38,8 @@ describe("TestSimpleP2E", () => {
     lpRecipient = checksumAddress(lpRecipientWallet.account.address);
     revenueRecipient = checksumAddress(revenueRecipientWallet.account.address);
 
-    // Deploy SimpleP2E ecosystem with Balancer V2 pool and initial liquidity
-    ({ woas, poasMinter, poas, smp, p2e, nativeOAS } = await deploySimpleP2E({
+    // Deploy SBTSale ecosystem with Balancer V2 pool and initial liquidity
+    ({ woas, poasMinter, poas, smp, p2e, nativeOAS } = await deploySBTSale({
       initialLiquidity: {
         woas: parseEther("1000"), // Initial WOAS liquidity
         smp: parseEther("4000"), // Initial SMP liquidity (4:1 ratio)

--- a/script/DeploySBTSale.s.sol
+++ b/script/DeploySBTSale.s.sol
@@ -4,13 +4,13 @@ pragma solidity >=0.8.0;
 import {Script, console} from "forge-std/Script.sol";
 import {TransparentUpgradeableProxy} from
     "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-import {SimpleP2E} from "../contracts/SimpleP2E.sol";
+import {SBTSale} from "../contracts/SBTSale.sol";
 
 /**
- * @title DeploySimpleP2E
- * @notice Deploys the SimpleP2E implementation and proxy.
+ * @title DeploySBTSale
+ * @notice Deploys the SBTSale implementation and proxy.
  */
-contract DeploySimpleP2E is Script {
+contract DeploySBTSale is Script {
     function run() external returns (TransparentUpgradeableProxy proxy) {
         address poasMinter = vm.envAddress("P2E_POAS_MINTER");
         address liquidityPool = vm.envAddress("P2E_LIQUIDITY_POOL");
@@ -33,7 +33,7 @@ contract DeploySimpleP2E is Script {
 
         vm.startBroadcast();
 
-        SimpleP2E implementation = new SimpleP2E(
+        SBTSale implementation = new SBTSale(
             poasMinter,
             liquidityPool,
             lpRecipient,
@@ -46,13 +46,13 @@ contract DeploySimpleP2E is Script {
         proxy = new TransparentUpgradeableProxy(
             address(implementation),
             admin,
-            abi.encodeWithSelector(SimpleP2E.initialize.selector, admin)
+            abi.encodeWithSelector(SBTSale.initialize.selector, admin)
         );
 
         // print deployment result
         bytes32 ADMIN_SLOT = 0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103;
         console.log("--------------------------------");
-        console.log("SimpleP2E(implementation):", address(implementation));
+        console.log("SBTSale(implementation):", address(implementation));
         console.log("ProxyAdmin:", address(uint160(uint256(vm.load(address(proxy), ADMIN_SLOT)))));
         console.log("Proxy:", address(proxy));
 

--- a/test/SBTSale.t.sol
+++ b/test/SBTSale.t.sol
@@ -10,7 +10,7 @@ import {IERC20} from "@balancer-labs/v2-interfaces/contracts/solidity-utils/open
 import {IVault} from "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
 
 // Local contracts and interfaces
-import {SimpleP2E} from "../contracts/SimpleP2E.sol";
+import {SBTSale} from "../contracts/SBTSale.sol";
 import {ISimpleP2E} from "../contracts/interfaces/ISimpleP2E.sol";
 import {IVaultPool} from "../contracts/interfaces/IVaultPool.sol";
 import {ISimpleP2EERC721} from "../contracts/interfaces/ISimpleP2EERC721.sol";
@@ -29,7 +29,7 @@ import {MockSMP} from "../contracts/test-utils/MockSMPv8.sol";
 import {MockPOASMinter} from "../contracts/test-utils/MockPOASMinter.sol";
 import {MockSimpleP2EERC721} from "../contracts/test-utils/MockSimpleP2EERC721.sol";
 
-contract SimpleP2ETest is Test {
+contract SBTSaleTest is Test {
     ISimpleP2E p2e;
     address p2eAddr;
 
@@ -119,7 +119,7 @@ contract SimpleP2ETest is Test {
             })
         );
 
-        SimpleP2E _p2e = new SimpleP2E({
+        SBTSale _sale = new SBTSale({
             poasMinter: address(poasMinter),
             liquidityPool: address(pool),
             lpRecipient: lpRecipient,
@@ -129,7 +129,7 @@ contract SimpleP2ETest is Test {
             smpLiquidityRatio: 4000
         });
 
-        p2eAddr = address(_p2e);
+        p2eAddr = address(_sale);
         p2e = ISimpleP2E(p2eAddr);
         woas = IERC20(address(_woas));
         poas = IPOAS(poasMinter.poas());


### PR DESCRIPTION
## Summary
- rename `SimpleP2E` contract to `SBTSale`
- update deployment script and env sample
- adjust tests and helpers for new name
- refresh README references

## Testing
- `npm test` *(fails: forge not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865ede349788330b1e8e43b83ef7654